### PR TITLE
COSI-29: Produce multi-architecture Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       packages: write
     uses: scality/workflows/.github/workflows/docker-build.yaml@v2
     with:
+      context: .
       name: cosi
       namespace: ${{ github.repository_owner }}
       tag: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,11 @@ jobs:
       packages: write
     uses: scality/workflows/.github/workflows/docker-build.yaml@v2
     with:
+      context: .
       name: cosi
       namespace: ${{ github.repository_owner }}
       tag: ${{ inputs.tag }}
+      platforms: linux/amd64,linux/arm64
 
   create-github-release:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM golang:1.23.2 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
-
-ENV CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
 
-RUN go build -o scality-cosi-driver ./cmd/scality-cosi-driver
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o scality-cosi-driver ./cmd/scality-cosi-driver
 
 FROM gcr.io/distroless/static:latest
 COPY --from=builder /app/scality-cosi-driver /scality-cosi-driver


### PR DESCRIPTION
In the context of COSI driver, the driver should be usable on any OS supported by Kubernetes. This will allow us to build arm64 images along with already produced amd64 images for released versions

Note: 
tested with development image here: https://github.com/scality/cosi/actions/runs/11571891091/job/32210731213
I removed the multi-arch from development builds as it takes a bit longer to produce them due to emulation.


Related PR from Platform Engineering: https://github.com/scality/workflows/pull/67