### PR TITLE
COSI-6: Add kind and upload log step to CI

### DIFF
--- a/.github/scripts/capture_k8s_logs.sh
+++ b/.github/scripts/capture_k8s_logs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Create a directory to store the logs
+mkdir -p logs/kind_cluster_logs
+LOG_FILE_PATH=".github/e2e_tests/artifacts/logs/kind_cluster_logs"
+mkdir -p "$(dirname "$LOG_FILE_PATH")"  # Ensure the log directory exists
+# Define namespaces to capture logs from
+namespaces=("default" "scality-object-storage")
+
+# Loop through specified namespaces, pods, and containers
+for namespace in "${namespaces[@]}"; do
+  for pod in $(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+    for container in $(kubectl get pod $pod -n $namespace -o jsonpath='{.spec.containers[*].name}'); do
+      # Capture current logs for each container
+      kubectl logs -n $namespace $pod -c $container > ${LOG_FILE_PATH}/_${namespace}_${pod}_${container}.log 2>&1
+      # Capture previous logs if the container has restarted
+      kubectl logs -n $namespace $pod -c $container --previous > ${LOG_FILE_PATH}/${namespace}_${pod}_${container}_previous.log 2>&1 || true
+    done
+  done
+done

--- a/.github/workflows/ci-build-and-unit-tests.yml
+++ b/.github/workflows/ci-build-and-unit-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Build and Unit Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: unit-tests-with-ginkgo
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -1,0 +1,54 @@
+name: CI End-to-End Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
+
+jobs:
+  e2e-tests-with-kind:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Create k8s KIND Cluster
+      uses: helm/kind-action@v1.10.0
+      with:
+        version: v0.21.0
+        wait: 90s
+        cluster_name: object-storage-cluster
+
+    - name: Verify KIND cluster is running
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      with:
+        detached: true
+
+    - name: Capture Kubernetes Logs in artifacts directory
+      run: |
+        chmod +x .github/scripts/capture_k8s_logs.sh
+        .github/scripts/capture_k8s_logs.sh
+      if: always()
+
+    - name: Upload logs and data to Scality artifacts
+      uses: scality/action-artifacts@v4
+      with:
+        method: upload
+        url: https://artifacts.scality.net
+        user: ${{ secrets.ARTIFACTS_USER }}
+        password: ${{ secrets.ARTIFACTS_PASSWORD }}
+        source: .github/e2e_tests/artifacts
+      if: always()


### PR DESCRIPTION
Add kind and upload log step to the CI
- Renamed '.github/workflows/ci.yml' to
  '.github/workflows/ci-build-and-unit-tests.yml'
  for development image build and unit tests
- Added new workflow '.github/workflows/ci-e2e-tests.yml' for end-to-end tests

The [next PR](https://github.com/scality/cosi/pull/10) contains the COSI deployment.
